### PR TITLE
Update just setup scripts to bootstrap/serve correctly

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,12 +11,13 @@ bootstrap:
     #!/usr/bin/env bash
     set -eu -o pipefail
     docker compose up -d
-    scripts/get_local_docker_ports.sh
-    scripts/get_web_port.sh
 
     # if our .env isn't there, this is probably a checkout;
     # we want to generate it instead.
     scripts/ensure_env.sh
+
+    scripts/get_local_docker_ports.sh
+    scripts/get_web_port.sh
 
     # we run this again to get the new environment locked in
     docker compose up -d

--- a/scripts/ensure_env.sh
+++ b/scripts/ensure_env.sh
@@ -28,6 +28,8 @@ NOM_OAUTH_KEY=bogon
 NOM_OAUTH_SECRET=bogon
 NOM_OAUTH_BACKEND=nom.oauth2_backends.DummyOAuth2Backend
 
+NOM_CONTROLL_JWT_KEY=bogonjwtkey
+
 NOM_EMAIL_HOST=localhost
 NOM_EMAIL_PORT=51025
 


### PR DESCRIPTION
I had to tweak the scripts a bit to get `just bootstrap` + `just serve` working correctly.

- The CONTROLL jwt key looks to be Seattle specific, so I don't think we need to add that back to the main `nomnom` repo.
- The `ensure-env.sh` order change looks to [already be in nomnom main](https://github.com/WorldconVotingSystems/nomnom/blob/eac473ee1263f635cbe89b2b6c53e4b140628d71/convention-template/justfile#L14-L21), so should be nothing to take back to the originating repo.