### PR TITLE
Feedback from soft launch

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,14 @@ icecream.install()
 logging.disable(logging.CRITICAL)
 
 
+@pytest.fixture(scope="session")
+def django_db_setup(django_db_setup, django_db_blocker):
+    from django.core.management import call_command
+
+    with django_db_blocker.unblock():
+        call_command("loaddata", "-v3", "all/0001-permissions.json")
+
+
 @pytest.fixture(autouse=True)
 def use_test_settings(settings):
     settings.DEBUG = False

--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ import icecream
 import pytest
 from django_svcs.apps import svcs_from
 from nomnom.convention import ConventionConfiguration
+from nomnom.nominate.models import NominatingMemberProfile
 
 icecream.install()
 
@@ -46,8 +47,13 @@ def user_factory():
     UserModel = get_user_model()
 
     def create_user(username=None, **kwargs):
+        create_convention_profile = kwargs.pop("with_convention_profile", False)
+
         username = username or uuid.uuid4().hex
-        return UserModel.objects.create(username=username, **kwargs)
+        user = UserModel.objects.create(username=username, **kwargs)
+        if create_convention_profile:
+            user.convention_profile = NominatingMemberProfile.objects.create(user=user)
+        return user
 
     return create_user
 

--- a/deploy/production/compose.yml
+++ b/deploy/production/compose.yml
@@ -103,6 +103,36 @@ services:
       retries: 5
       start_period: 5s
 
+  # This container and Dozzle provide a logging endpoint access over my personal tailnet,
+  # so that I can view the container logs on this host without ssh as needed.
+  tailscale-sidecar:
+    hostname: nomnom-seattle2025-prod-logs
+    volumes:
+      - tailscale-data:/var/lib/tailscale
+    devices:
+      - /dev/net/tun
+    cap_add: # Required for tailscale to work
+      - net_admin
+      - sys_module
+    environment:
+      - TS_SERVE_PORT=8080
+    image: ghcr.io/offbyone/sidecar:main
+
+  dozzle:
+    container_name: dozzle
+    image: amir20/dozzle:latest
+    network_mode: "service:tailscale-sidecar"
+    restart: unless-stopped
+    environment:
+      DOZZLE_HOSTNAME: "nomnom-seattle2025-prod-logs"
+      DOZZLE_AUTH_PROVIDER: forward-proxy
+      DOZZLE_AUTH_HEADER_USER: "Tailscale-User-Login"
+      DOZZLE_AUTH_HEADER_NAME: "Tailscale-User-Name"
+      DOZZLE_ENABLE_ACTIONS: "false"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
 volumes:
   db-data:
   staticfiles:
+  tailscale-data:

--- a/seattle_2025_app/admin.py
+++ b/seattle_2025_app/admin.py
@@ -1,0 +1,22 @@
+from django.contrib import admin
+from nomnom.nominate.admin import CustomUserAdmin
+
+from .models import ControllPerson
+
+
+class ControllPersonInline(admin.StackedInline):
+    model = ControllPerson
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_add_permission(self, request, obj):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return False
+
+    readonly_fields = ["perid", "newperid"]
+
+
+CustomUserAdmin.inlines.append(ControllPersonInline)

--- a/seattle_2025_app/auth.py
+++ b/seattle_2025_app/auth.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import BaseBackend
 from django.contrib.auth.models import AbstractUser, Group
 from django.db import transaction
+from django.db.models import ObjectDoesNotExist
 from django_svcs.apps import svcs_from
 from nomnom.convention import ConventionConfiguration
 from nomnom.nominate import models as nominate
@@ -80,6 +81,16 @@ class ControllBackend(BaseBackend):
                     match = matches.first()
                     match.perid = perid
                     match.save()
+
+                    # we also need to update the member number.
+                    try:
+                        convention_profile = match.user.convention_profile
+                        convention_profile.member_number = perid
+                        convention_profile.save()
+
+                    except ObjectDoesNotExist:
+                        pass
+
                     return match.user
 
             # we don't perform creation in this, just lookups. We only save the perid

--- a/seattle_2025_app/templates/bits/convention_header.html
+++ b/seattle_2025_app/templates/bits/convention_header.html
@@ -4,27 +4,22 @@
         <ul class="navbar-nav ml-lg-auto">
             {% if request.user.is_staff %}
                 <li class="nav-item dropdown">
-                    <a class="nav-link" href="{% url "admin:index" %}">
-                        {% translate "Admin Dashboard" %}
-                    </a>
+                    <a class="nav-link" href="{% url "admin:index" %}">{% translate "Admin Dashboard" %}</a>
                 </li>
             {% endif %}
             <li class="nav-item dropdown text-primary">
-                <a class="nav-link" href="{{ CONVENTION_SITE_URL }}">
-                    {% translate "Seattle Worldcon 2025" %}
-                </a>
+                <a class="nav-link" href="{{ CONVENTION_SITE_URL }}">{% translate "Seattle Worldcon 2025" %}</a>
+            </li>
+            <li class="nav-item dropdown text-primary">
+                <a class="nav-link" href="https://reg.seattlein2025.org/">{% translate "Membership" %}</a>
             </li>
             {% if user.is_authenticated %}
                 <li class="nav-item">
-                    <a class="nav-link" href="{% url 'election:index' %}">
-                        {% translate "Hugo Awards" %}
-                    </a>
+                    <a class="nav-link" href="{% url 'election:index' %}">{% translate "Hugo Awards" %}</a>
                 </li>
                 {% if ADVISORY_VOTES %}
                     <li class="nav-item">
-                        <a class="nav-link" href="{% url 'advise:advisory_votes' %}">
-                            {% translate "Advisory Votes" %}
-                        </a>
+                        <a class="nav-link" href="{% url 'advise:advisory_votes' %}">{% translate "Advisory Votes" %}</a>
                     </li>
                 {% endif %}
                 <li class="nav-logout">

--- a/seattle_2025_app/tests/test_auth.py
+++ b/seattle_2025_app/tests/test_auth.py
@@ -64,6 +64,32 @@ def test_authenticate_updates_perid_with_newperid(
     assert person.newperid == ONLY_NEWPERID  # Should remain unchanged
 
 
+def test_authenticate_updates_member_id_when_updating_perid(
+    db, user_factory, controll_person_factory, backend
+):
+    user = user_factory(with_convention_profile=True)
+
+    person = controll_person_factory(user=user, newperid=ONLY_NEWPERID)
+    assert person.perid is None
+
+    # Mock a token with both perid and newperid
+    token = jwt.encode(
+        {"perid": UPDATED_PERID, "newperid": ONLY_NEWPERID},
+        settings.CONTROLL_JWT_KEY,
+        algorithm="HS256",
+    )
+
+    # Run authentication
+    authenticated_user = backend.authenticate(None, token=token)
+
+    # Reload record from the database
+    person.refresh_from_db()
+
+    # Assertions
+    assert authenticated_user == person.user  # Should match the user already in DB
+    assert authenticated_user.convention_profile.member_number == UPDATED_PERID
+
+
 def test_authenticate_doesnt_create_new_row_for_perid(db, backend):
     # Mock a token with an unrecognized perid
     token = jwt.encode(

--- a/seattle_2025_app/tests/test_auth.py
+++ b/seattle_2025_app/tests/test_auth.py
@@ -90,6 +90,60 @@ def test_authenticate_updates_member_id_when_updating_perid(
     assert authenticated_user.convention_profile.member_number == UPDATED_PERID
 
 
+def test_authenticate_by_perid_updates_wsfs_rights(
+    db, user_factory, controll_person_factory, backend, convention
+):
+    user = user_factory()
+
+    person = controll_person_factory(user=user, perid=EXISTING_PERID)
+
+    # Mock a token with both perid and newperid
+    token = jwt.encode(
+        {"perid": EXISTING_PERID, "newperid": None, "rights": "hugo_nominate"},
+        settings.CONTROLL_JWT_KEY,
+        algorithm="HS256",
+    )
+
+    # Run authentication
+    authenticated_user = backend.authenticate(None, token=token)
+
+    # Reload record from the database
+    person.refresh_from_db()
+
+    # Assertions
+    assert authenticated_user == person.user  # Should match the user already in DB
+    assert convention.nominating_group in person.user.groups.values_list(
+        "name", flat=True
+    )
+
+
+def test_authenticate_by_newperid_updates_wsfs_rights(
+    db, user_factory, controll_person_factory, backend, convention
+):
+    user = user_factory()
+
+    person = controll_person_factory(user=user, newperid=EXISTING_NEWPERID)
+
+    # Mock a token with both perid and newperid
+    token = jwt.encode(
+        {"perid": None, "newperid": EXISTING_NEWPERID, "rights": "hugo_nominate"},
+        settings.CONTROLL_JWT_KEY,
+        algorithm="HS256",
+    )
+
+    # Run authentication
+    authenticated_user = backend.authenticate(None, token=token)
+
+    # Reload record from the database
+    person.refresh_from_db()
+
+    # Assertions
+    assert authenticated_user == person.user  # Should match the user already in DB
+    assert convention.nominating_group in person.user.groups.values_list(
+        "name", flat=True
+    )
+
+
 def test_authenticate_doesnt_create_new_row_for_perid(db, backend):
     # Mock a token with an unrecognized perid
     token = jwt.encode(

--- a/seattle_2025_app/tests/test_views.py
+++ b/seattle_2025_app/tests/test_views.py
@@ -5,7 +5,6 @@ import jwt
 import pytest
 from django.contrib.auth import get_user, get_user_model
 from django.contrib.auth.models import AbstractUser
-from django.core.management import call_command
 
 from seattle_2025_app.models import ControllPerson
 
@@ -36,12 +35,6 @@ syd_full_token = {
     "resType": "fullRights",
     "rights": "hugo_nominate,hugo_vote",
 }
-
-
-@pytest.fixture(scope="session")
-def django_db_setup(django_db_setup, django_db_blocker):
-    with django_db_blocker.unblock():
-        call_command("loaddata", "-v3", "all/0001-permissions.json")
 
 
 @pytest.fixture(name="make_token")
@@ -191,7 +184,7 @@ def test_new_member_permission(
     )
 
     user: AbstractUser = get_user(client)
-    user_group_names = [g.name for g in user.groups.all()]
+    user_group_names = user.groups.values_list("name", flat=True)
     assert (convention.nominating_group in user_group_names) == can_nominate
     assert (convention.voting_group in user_group_names) == can_vote
 


### PR DESCRIPTION
- When ConTroll sends a perid, we want to update the member number in thea
  convention profile
- Display the ConTroll perid/newperid in the admin UI
- When NomNom receives a login, refresh the set of permissions for the member.
- Include a link to the reg portal from the voting page