### PR TITLE
Small changes to nomination_instructions.html

### DIFF
--- a/seattle_2025_app/templates/nominate/bits/nomination_instructions.html
+++ b/seattle_2025_app/templates/nominate/bits/nomination_instructions.html
@@ -1,5 +1,5 @@
 <h2>Deadline</h2>
-All ballots must be <strong><u>received</u></strong> by <strong>March 14, 2025, 23:59 PDT</strong>
+All ballots must be <strong>received</strong> by <strong>March 14, 2025, 23:59 PDT</strong>
 <h2>How to Nominate (NomNom)</h2>
 <p>
     You may nominate up to 5 persons or works in each category. You are permitted (and encouraged) to make fewer nominations or none at all if you are not familiar with the candidates in a category. The order in which you list your nominations has no effect on the outcome.
@@ -8,10 +8,11 @@ All ballots must be <strong><u>received</u></strong> by <strong>March 14, 2025, 
     <li>Enter your nominations in the text fields of the appropriate categories.</li>
     <li>
         Click ‘Save as you go’ to save your entries.
-        <ol>
+        <ul>
             <li>‘Save all’ at the bottom of the page performs the same function and will save a current version of the ballot.</li>
             <li>This form does not autosave!</li>
-        </ol>
+            <li>A green check mark shows next to each item when it saves.</li>
+        </ul>
     </li>
     <li>Complete your nominations, and return to make as many changes as you want up until the deadline.</li>
     <li>Send yourself an email copy of your most recent saved ballot by selecting ‘Email my nominations to me’</li>


### PR DESCRIPTION
Belatedly addressing https://github.com/WorldconVotingSystems/seattle-2025/issues/24 and https://github.com/WorldconVotingSystems/seattle-2025/issues/25

It’s too late to make this change for this year, but I figured I might as well make it in case next year’s team uses these files as a starting point.

Fixes #24 
Fixes #25 